### PR TITLE
ci: avoid building twice

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -19,8 +19,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
       - run: swift --version
-      - run: swift build
-      - run: swift test --disable-xctest --enable-code-coverage --no-parallel
+      - run: swift build --build-tests --disable-xctest --enable-code-coverage
+      - run: swift test --skip-build --disable-xctest --enable-code-coverage --no-parallel
       - run: llvm-cov export -format="lcov" .build/debug/swift-boxPackageTests.swift-testing -instr-profile .build/debug/codecov/default.profdata -ignore-filename-regex=".build|Tests" > coverage_report.lcov
       - uses: k1LoW/octocov-action@v1
   lint:


### PR DESCRIPTION
The same reason as https://github.com/kkebo/zyphy/pull/91