### PR TITLE
ci: remove `--no-parallel` from `swift test`

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,7 +20,7 @@ jobs:
             ${{ runner.os }}-spm-
       - run: swift --version
       - run: swift build --build-tests --disable-xctest --enable-code-coverage
-      - run: swift test --skip-build --disable-xctest --enable-code-coverage --no-parallel
+      - run: swift test --skip-build --disable-xctest --enable-code-coverage
       - run: llvm-cov export --format=lcov .build/debug/swift-boxPackageTests.swift-testing --instr-profile .build/debug/codecov/default.profdata --ignore-filename-regex=".build|Tests" > coverage_report.lcov
       - uses: k1LoW/octocov-action@v1
   lint:


### PR DESCRIPTION
In the past, `swift test` cannot generate a coverage report properly without `--no-parallel`, but it is no longer needed.