### PR TITLE
ci: fix CI

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -21,7 +21,7 @@ jobs:
       - run: swift --version
       - run: swift build --build-tests --disable-xctest --enable-code-coverage
       - run: swift test --skip-build --disable-xctest --enable-code-coverage
-      - run: llvm-cov export --format=lcov .build/debug/swift-boxPackageTests.swift-testing --instr-profile .build/debug/codecov/default.profdata --ignore-filename-regex=".build|Tests" > coverage_report.lcov
+      - run: llvm-cov export --format=lcov .build/debug/swift-boxPackageTests.xctest --instr-profile .build/debug/codecov/default.profdata --ignore-filename-regex=".build|Tests" > coverage_report.lcov
       - uses: k1LoW/octocov-action@v1
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
swift-boxPackageTests.xctest and swift-boxPackageTests.swift-testing are now merged into swift-boxPackageTests.xctest in the latest toolchain.
