### PR TITLE
ci: Swift 6.0

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-6.0-jammy
+    container: swift:6.0
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,7 +25,7 @@ jobs:
       - uses: k1LoW/octocov-action@v1
   lint:
     runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-main-jammy
+    container: swift:6.0
     steps:
       - uses: actions/checkout@v4
       - run: swift format lint -rs .


### PR DESCRIPTION
Swift 6.0.0 has officially been released, so let's use the Swift 6.0 image in CI.